### PR TITLE
Bundler / .gitignore

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: ".bundle"
+BUNDLE_DISABLE_SHARED_GEMS: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
-_site
-.sass-cache
+# Generated site
+/_site
+
+# Local packages
+/.bundle/ruby/
+
+# Temporary files
+.sass-cache/
+.jekyll-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.0"
+gem "rouge", "~> 1.0"
+
+group :jekyll_plugins do
+  gem "jekyll-feed"
+  gem "jekyll-paginate"
+  gem "jekyll-sitemap"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,60 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.6.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 3)
+      safe_yaml (~> 1.0)
+    jekyll-feed (0.9.2)
+      jekyll (~> 3.3)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-sitemap (1.1.1)
+      jekyll (~> 3.3)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.15.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (~> 3.0)
+  jekyll-feed
+  jekyll-paginate
+  jekyll-sitemap
+  rouge (~> 1.0)
+
+BUNDLED WITH
+   1.13.6

--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ author:
 ## You should not change anything here unless you know what you are doing
 
 # Gems
-gems:
+plugins:
   - jekyll-paginate
   - jekyll-sitemap
 


### PR DESCRIPTION
This adds support for bundler (and adds a `.gitignore`), so people can try it out easily on their local machines with the usual

    bundle install
    bundle exec jekyll serve